### PR TITLE
Correct filename in yml file

### DIFF
--- a/schemas.yml
+++ b/schemas.yml
@@ -5,5 +5,5 @@ version: 0.1.0
 
 schemas:
   -
-    path: "schema.json"
+    path: "structures.json"
     title: "Structures de l'insertion"


### PR DESCRIPTION
Ok my bad, I set up wrong filename in `schemas.yml` file. It should refers to your jsonschema file, we use to have `schema.json` in other schemas but here it is `structures.json` (which is not a problem, keep it that way).

So you have to : 
- Accept this PR
- Remove all releases and tags from v0.1.0
- Recreate a release and a tag with master code to v0.1.0

It would be automatically integrate to schema.data.gouv.fr

